### PR TITLE
fix: Refactor assignment of product field

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -192,12 +192,22 @@ exports.onCreateNode = async ({
     node.relationships &&
     node.relationships.products
   ) {
-    node.products___NODE = await Promise.all(
-      node.relationships.products.data.map(async ({ id }) => {
-        const { id: productNode } = await getNode(id)
+    const getProductNodes = async () => {
+      const productIds = node.relationships.products.data.map(
+        product => product.id
+      )
 
-        return productNode
+      let productNodes = []
+
+      await productIds.forEach(async productId => {
+        const productNode = await getNode(productId)
+
+        if (productNode) productNodes.push(productNode.id)
       })
-    )
+
+      return productNodes
+    }
+
+    node.products___NODE = await getProductNodes()
   }
 }


### PR DESCRIPTION
Only return an array of product nodes actually created.

In some instances categories, collections have relationships to draft products. The implicit nature of this plugin means those product nodes are not created, thus the Gatbsy site build would fail