### PR TITLE
chore: Add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   ],
   "devDependencies": {
     "semantic-release": "^15.13.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Determine access should be public despite being a scoped package