### PR TITLE
fix: removes shadowed variable breaking merge code

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -186,7 +186,6 @@ exports.sourceNodes = async (
         return response
 
       const {
-        data,
         links: { next }
       } = response
 


### PR DESCRIPTION
Remove the `data` local variable as it was shadowing the `data` variable used in `getPaginatedResource`. This prevented the merged data from being passed to the recursive call to `getPaginatedResource`.

NOTE: This looks like tail recursion so I'll have a followup PR to change this to a for loop. But, for now, this fixes the bug preventing merging from working properly.