### PR TITLE
fix: Return merged resources from recursive call.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -189,7 +189,7 @@ exports.sourceNodes = async (
         links: { next }
       } = response
 
-      var merged = merge(data, response)
+      let merged = merge(data, response)
 
       if (next) {
         const { search } = new URL(next)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -189,11 +189,11 @@ exports.sourceNodes = async (
         links: { next }
       } = response
 
-      const merged = merge(data, response)
+      var merged = merge(data, response)
 
       if (next) {
         const { search } = new URL(next)
-        getPaginatedResource(resource, merged, search)
+        merged = getPaginatedResource(resource, merged, search)
       }
 
       return merged


### PR DESCRIPTION
This changes `getPaginatedResource` to return the merged resources from its recursive call. Prior to this fix it was always returning the resources only from the first call and dropping the remaining merged resources incorrectly.